### PR TITLE
Adapt to new API endpoint and response format

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -47,7 +47,7 @@ for tuya_device in device_manager.device_map.values():
         resp = openapi.get('/v1.0/devices/factory-infos?device_ids={}'.format(tuya_device.id))
         factory_info = resp['result'][0]
         if 'mac' in factory_info:
-            mac = factory_info['mac']
+            mac = factory_info['mac'].upper()
             if not mac_format.match(mac):
                 mac = ':'.join(factory_info['mac'][i:i + 2] for i in range(0, 12, 2))
             device['mac_address'] = mac

--- a/extract.py
+++ b/extract.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 
 from config import (
     ENDPOINT,
@@ -19,6 +20,7 @@ from tuya_iot import (
     TuyaDeviceManager,
 )
 
+mac_format = re.compile(r"(?:[0-9A-Fa-f]{2}\:){5}(?:[0-9A-Fa-f]{2})")
 
 openapi = TuyaOpenAPI(ENDPOINT, ACCESS_ID, ACCESS_KEY, AuthType.SMART_HOME)
 openapi.connect(EMAIL, PASSWORD, country_code=COUNTRY_CODE, schema=APP.value)
@@ -42,10 +44,12 @@ for tuya_device in device_manager.device_map.values():
     }
 
     try:
-        resp = openapi.get('/v1.0/iot-03/devices/factory-infos?device_ids={}'.format(tuya_device.id))
+        resp = openapi.get('/v1.0/devices/factory-infos?device_ids={}'.format(tuya_device.id))
         factory_info = resp['result'][0]
         if 'mac' in factory_info:
-            mac = ':'.join(factory_info['mac'][i:i + 2] for i in range(0, 12, 2))
+            mac = factory_info['mac']
+            if not mac_format.match(mac):
+                mac = ':'.join(factory_info['mac'][i:i + 2] for i in range(0, 12, 2))
             device['mac_address'] = mac
     except Exception as e:
         print(e)


### PR DESCRIPTION
I was using [ha_tuya_ble](https://github.com/PlusPlus-ua/ha_tuya_ble) and I cannot add my fingerbot where I keeps getting the error message of `Device is not registered in Tuya cloud`. After some research I found that the author borrowed the logic for fetching local keys and MAC from this repo. I tried the code, it spat out the local key but not the MAC address, which is critical for Home Assistant BLE to match the local device.

After some research I found that Tuya changed their API endpoint where the `iot-03` no longer exists. Also I am not sure what format the MAC address it's returning before, but now it seems to return a normal colon separated string. The old logic will generate garbage so I added a judgement.

After adapting the change into `ha_tuya_ble` I can get my device connected successfully.
